### PR TITLE
[refs #00025] Modified Breadcrumbs based on Nightingale design

### DIFF
--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -73,6 +73,8 @@ class core_renderer extends \core_renderer {
 
         // Moved breadcrumbs before heading as per Nightingale design
         $pageheadingbutton = $this->page_heading_button();
+
+        $html = "";
         if (empty($PAGE->layout_options['nonavbar'])) {
           $html = html_writer::start_div('clearfix w-100 pull-xs-left', array('id' => 'page-navbar'));
           $html .= html_writer::tag('div', $this->navbar(), array('class' => 'breadcrumb-nav'));

--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -71,7 +71,17 @@ class core_renderer extends \core_renderer {
     public function full_header() {
         global $PAGE;
 
-        $html = html_writer::start_tag('header', array('id' => 'page-header', 'class' => 'row'));
+        // Moved breadcrumbs before heading as per Nightingale design
+        $pageheadingbutton = $this->page_heading_button();
+        if (empty($PAGE->layout_options['nonavbar'])) {
+          $html = html_writer::start_div('clearfix w-100 pull-xs-left', array('id' => 'page-navbar'));
+          $html .= html_writer::tag('div', $this->navbar(), array('class' => 'breadcrumb-nav'));
+          $html .= html_writer::end_div();
+          $html .= html_writer::start_tag('hr', array('class' => 'c-divider'));
+        }
+
+        // Heading with course or page headers
+        $html .= html_writer::start_tag('header', array('id' => 'page-header', 'class' => 'row'));
         $html .= html_writer::start_div('col-xs-12 p-a-1');
         $html .= html_writer::start_div('card');
         $html .= html_writer::start_div('card-block');
@@ -79,15 +89,6 @@ class core_renderer extends \core_renderer {
         $html .= html_writer::start_div('pull-xs-left');
         $html .= $this->context_header();
         $html .= html_writer::end_div();
-        $pageheadingbutton = $this->page_heading_button();
-        if (empty($PAGE->layout_options['nonavbar'])) {
-            $html .= html_writer::start_div('clearfix w-100 pull-xs-left', array('id' => 'page-navbar'));
-            $html .= html_writer::tag('div', $this->navbar(), array('class' => 'breadcrumb-nav'));
-            $html .= html_writer::div($pageheadingbutton, 'breadcrumb-button pull-xs-right');
-            $html .= html_writer::end_div();
-        } else if ($pageheadingbutton) {
-            $html .= html_writer::div($pageheadingbutton, 'breadcrumb-button nonavbar pull-xs-right');
-        }
         $html .= html_writer::tag('div', $this->course_header(), array('id' => 'course-header'));
         $html .= html_writer::end_div();
         $html .= html_writer::end_div();

--- a/style/_settings.pre-config.scss
+++ b/style/_settings.pre-config.scss
@@ -14,4 +14,3 @@
 $asset-path: '/nightingale/assets/';
 $font-path: '#{$asset-path}fonts/';
 $image-path: '#{$asset-path}img/';
-$global-hints: false;

--- a/style/_settings.pre-config.scss
+++ b/style/_settings.pre-config.scss
@@ -14,3 +14,4 @@
 $asset-path: '/nightingale/assets/';
 $font-path: '#{$asset-path}fonts/';
 $image-path: '#{$asset-path}img/';
+$global-hints: false;

--- a/style/main.scss
+++ b/style/main.scss
@@ -1,3 +1,4 @@
 @import "settings.pre-config";
 @import "nightingale/main";
 @import "middleware/middleware.header";
+@import "middleware/middleware.breadcrumb";

--- a/style/middleware/_middleware.breadcrumb.scss
+++ b/style/middleware/_middleware.breadcrumb.scss
@@ -1,0 +1,29 @@
+/* ==========================================================================
+   #BREADCRUMBS
+   ========================================================================== */
+/**
+ * Unfortunately, Moodle provides Breadcrumbs that we cannot actually get access to
+ * in order to add new classes. Here we’re just remapping its selector onto
+ * the cleaner Nightingale ones.
+ */
+
+div.breadcrumb-nav nav{
+  @extend .c-breadcrumb;
+}
+
+ol.breadcrumb {
+  @extend .c-breadcrumb__list;
+}
+
+li.breadcrumb-item {
+  @extend .c-breadcrumb__item;
+}
+
+li.breadcrumb-item a {
+  @extend .c-breadcrumb__link;
+}
+
+ol.breadcrumb>li:first-child a {
+  @extend .c-breadcrumb__link;
+  @extend .c-sprite, .c-sprite--home;
+}


### PR DESCRIPTION
@cehwitham - Please review the Breadcrumbs PR

Screenshot of what it looks like on my local
<img width="1280" alt="screen shot 2017-09-04 at 14 59 48" src="https://user-images.githubusercontent.com/25176815/30029675-122c1dca-9182-11e7-9902-fd20ac29bd0e.png">

The space above headcrumbs will be adjusted in [tkt-00024](https://github.com/NHSLeadership/moodle-theme_nightingale/issues/24)

