### PR TITLE
Tkt 00034 Home Page

### DIFF
--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -752,17 +752,17 @@ class core_renderer extends \core_renderer {
 
       $html = "";
 
+      // Display Forums on right in Blocks section.
+      $html .= $this->get_course_forum_section();
+
       if (empty($PAGE->layout_options['nonavbar'])) {
         $html .= html_writer::start_div('breadcrumb-button navbar pull-xs-right');
       } else if ($pageheadingbutton) {
         $html .= html_writer::div($pageheadingbutton, 'breadcrumb-button nonavbar pull-xs-right');
       }
-      $html .= html_writer::start_tag('hr', array('class' => 'c-divider'));
+
       $html .= $pageheadingbutton;
       $html .= html_writer::end_div();
-
-      // Display Forums on right in Blocks section.
-      $html .= $this->get_course_forum_section();
 
       return $html;
   }

--- a/layout/columns2.php
+++ b/layout/columns2.php
@@ -72,6 +72,7 @@ $templatecontext = [
     'footnote'  => $themesettings->footnote,
     'partnershipinfo' => $themesettings->partnershipinfo,
     'ribbonhtml'=> $themesettings->ribbonhtml,
+    'cookieribbonhtml' => $themesettings->cookieribbonhtml,
     'logosrc'   => $themesettings->logosrc,
     'sublogosrc'=> $themesettings->sublogosrc,
     'siteadminlink' => $siteadminhtml,

--- a/layout/login.php
+++ b/layout/login.php
@@ -23,10 +23,14 @@ defined('MOODLE_INTERNAL') || die();
  */
 
 $bodyattributes = $OUTPUT->body_attributes();
+$themesettings = theme_nightingale_get_html_for_settings($OUTPUT, $PAGE);
+
 
 $templatecontext = [
     'sitename' => format_string($SITE->shortname, true, ['context' => context_course::instance(SITEID), "escape" => false]),
     'output' => $OUTPUT,
+    'cookieribbonhtml' => $themesettings->cookieribbonhtml,
+    'logosrc'   => $themesettings->logosrc,
     'bodyattributes' => $bodyattributes
 ];
 

--- a/style/main.scss
+++ b/style/main.scss
@@ -11,6 +11,7 @@
 @import "middleware/middleware.course-listing";
 @import "middleware/middleware.course-view";
 @import "middleware/middleware.login";
+@import "middleware/middleware.home";
 
 /*
  * Importing Moodle related SASS for v1

--- a/style/middleware/_middleware.course-listing.scss
+++ b/style/middleware/_middleware.course-listing.scss
@@ -32,8 +32,8 @@
   display: none;
 }
 
-// Hide 'General' section (Forums list) from Course Listing display as that would be displayed on right
-.course-content .topics li[id="section-0"] {
+// Hide 'General' section (Forums list) from Course Listing display as that would be displayed on right for Topics & Weeks course formats
+.course-content .topics li[id="section-0"], .course-content .weeks li[id="section-0"] {
   display: none;
 }
 

--- a/style/middleware/_middleware.generic.scss
+++ b/style/middleware/_middleware.generic.scss
@@ -96,3 +96,13 @@ ul.nav-tabs > li > a.active {
   @extend .c-tabs__link;
   @extend .is-current;
 }
+
+// Overriding Hints, not switching them off
+img:not([alt]) {
+  outline: none;
+}
+
+// Some margin space just before the footer, at the end of main content area
+.o-layout--wide {
+  margin-bottom: $global-spacing-unit;
+}

--- a/style/middleware/_middleware.home.scss
+++ b/style/middleware/_middleware.home.scss
@@ -1,0 +1,47 @@
+/* ==========================================================================
+   #HOME PAGE / FRONT PAGE
+   ========================================================================== */
+
+// Hide Skip links
+a.skip-block {
+  display: none;
+}
+
+// Hide Site News block
+div[id="site-news-forum"] {
+  display: none;
+}
+
+// Hide Main Menu block; any Static pages to be added off Base
+aside.block_site_main_menu {
+  display: none;
+}
+
+// Course Cards on Home & Course Index page
+div[id="frontpage-course-list"] div.courses.frontpage-course-list-all, div.course_category_tree div.courses.category-browse {
+  @extend .c-media;
+}
+
+div[id="frontpage-course-list"] div.courses.frontpage-course-list-all div.coursebox, div.course_category_tree div.courses.category-browse div.coursebox {
+  @extend .c-media__masthead;
+  margin-bottom: $global-spacing-unit;
+}
+
+div[id="frontpage-course-list"] div.coursebox div.content, div.course_category_tree div.coursebox div.content {
+  min-height: 5 * $global-spacing-unit;
+}
+
+div[id="frontpage-course-list"] div.coursebox div.content div.courseimage img, div.course_category_tree div.coursebox div.content div.courseimage img {
+  @extend .c-media__media;
+}
+
+div[id="frontpage-course-list"] div.courses.frontpage-course-list-all div.coursebox div.info, div.course_category_tree div.courses.category-browse div.coursebox div.info {
+  @extend .c-media__emblem;
+}
+
+// Changing font styling of Course title to be slightly smaller for Course cards than usual <h3> fonts
+div[id="frontpage-course-list"] div.courses.frontpage-course-list-all div.coursebox div.info h3, div.course_category_tree div.courses.category-browse div.coursebox div.info h3 {
+  @extend .c-media__emblem;
+  line-height: 1.52;
+  font-size: $global-font-size-h4;
+}

--- a/style/middleware/_middleware.login.scss
+++ b/style/middleware/_middleware.login.scss
@@ -3,9 +3,9 @@
    ========================================================================== */
 
 // Generic
-.c-login-divider {
-  @extend .c-page-header;
-  padding: 0;
+.c-divider-login {
+  @extend .c-divider;
+  margin-top: $global-spacing-unit-small;
 }
 
 .c-login-title {
@@ -44,4 +44,9 @@ div.forgetpass {
 // Hide repetitive error message as it's a duplicate
 div.loginerrors a.accesshide {
   display: none;
+}
+
+// Remove extra padding for header on Login page only
+header[id="jsPageHeaderLogin"] {
+  padding: 0;
 }

--- a/templates/columns2.mustache
+++ b/templates/columns2.mustache
@@ -86,13 +86,15 @@
             </section>
             {{#hasblocks}}
             <section data-region="blocks-column" class="hidden-print o-layout__item u-4/12@lg">
-                {{{output.search_forum_form}}}
+                <hr class="c-divider"/>
                 {{{ sidepreblocks }}}
+                {{{ output.search_forum_form }}}
             </section>
             {{/hasblocks}}
             {{^hasblocks}}
                 <section data-region="blocks-column" class="hidden-print o-layout__item u-4/12@lg">
-                    {{{output.search_forum_form}}}
+                   <hr class="c-divider"/>
+                    {{{ output.search_forum_form }}}
                 </section>
             {{/hasblocks}}
         </div>

--- a/templates/core/login.mustache
+++ b/templates/core/login.mustache
@@ -92,20 +92,10 @@
 }}
 
 <div class="m-y-3 hidden-sm-down"></div>
-{{{ cookieribbonhtml }}}
 <div class="row">
     <div class="col-xl-6 push-xl-3 m-2-md col-sm-8 push-sm-2">
         <div class="card">
             <div class="card-block">
-                <div class="card-title text-xs-center">
-                    {{#logourl}}
-                        <h2><img src="{{logourl}}" title="{{sitename}}" alt="{{sitename}}" width="204" height="62" class="c-page-header__logo" /></h2>
-                    {{/logourl}}
-                    {{^logourl}}
-                        <h2>{{sitename}}</h2>
-                    {{/logourl}}
-                    <div class="c-login-divider"></div>
-                </div>
 
                 {{#cansignup}}
                     <div class="sr-only">
@@ -116,7 +106,7 @@
                 <div class="o-layout o-layout-wide">
                     {{#hasinstructions}}
                     <div class="row o-layout__item u-8/12@lg">
-                        <hr class="c-divider"/>
+                        <hr class="c-divider-login" />
                         <div class="col-xl-6 push-xl-3 m-2-md col-sm-8 push-sm-2">
                             <div class="card">
                                 <div class="card-block">
@@ -138,7 +128,7 @@
                     </div>
                     {{/hasinstructions}}
                     <div class="row o-layout__item u-4/12@lg">
-                        <hr class="c-divider"/>
+                        <hr class="c-divider-login"/>
                         <div class="col-md-4 push-md-1">
                             <h2 class="c-login-title">Login</h2>
                            {{#error}}

--- a/templates/header.mustache
+++ b/templates/header.mustache
@@ -23,7 +23,7 @@
 
     <div class="o-wrapper  c-page-header__inner">
 
-          <a href="{{{config.wwwroot}}}/my" class="c-page-header__lockup">
+          <a href="{{{config.wwwroot}}}/" class="c-page-header__lockup">
             <img src="{{{ logosrc }}}" alt="NHS" width="204" height="62" class="c-page-header__logo">
           </a>
 

--- a/templates/login.mustache
+++ b/templates/login.mustache
@@ -46,6 +46,20 @@
 
     <div id="page" class="container-fluid">
         <div id="page-content" class="row">
+            <header role="banner" class="c-page-header" id="jsPageHeaderLogin">
+                <div class="o-wrapper">
+                    {{{ cookieribbonhtml }}}
+                    <div class="card-title text-xs-center">
+                        {{#logosrc}}
+                            <h2><img src="{{logosrc}}" title="{{sitename}}" alt="{{sitename}}" width="204" height="62" class="c-page-header__logo" /></h2>
+                        {{/logosrc}}
+                        {{^logosrc}}
+                            <h2>{{sitename}}</h2>
+                        {{/logosrc}}
+                    </div>
+                </div>
+            </header>
+
             <div id="region-main-box" class="o-wrapper">
                 <section id="region-main" class="col-xs-12">
                     {{{ output.course_content_header }}}

--- a/templates/login.mustache
+++ b/templates/login.mustache
@@ -47,8 +47,8 @@
     <div id="page" class="container-fluid">
         <div id="page-content" class="row">
             <header role="banner" class="c-page-header" id="jsPageHeaderLogin">
+                {{{ cookieribbonhtml }}}
                 <div class="o-wrapper">
-                    {{{ cookieribbonhtml }}}
                     <div class="card-title text-xs-center">
                         {{#logosrc}}
                             <h2><img src="{{logosrc}}" title="{{sitename}}" alt="{{sitename}}" width="204" height="62" class="c-page-header__logo" /></h2>


### PR DESCRIPTION
The Home page page bits done are

- 2 column layout
- Right-side blocks
- Removed Site news & Main Menu blocks
- Created Course Cards with bit of custom changes to suit Moodle's default functionalities & code structure 
(Found Course Setting > Course Summary files to upload background image)
- Course Cards tidied up on Course Index page
- Fixed Login blue-purple border to go full-width in this issue itself

Issues such as Course Cards in more detail as per designs, minute responsiveness issue on devices such as iPhone 5 is noted in separate [ticket](https://github.com/NHSLeadership/moodle-theme_nightingale/issues/47)


Login Page with full-width border in header

![Login Page](https://user-images.githubusercontent.com/25176815/32564169-45912320-c4ab-11e7-8646-5c92a7f471ca.png)

Home Page on Local with & without Course background images

![Home page](https://user-images.githubusercontent.com/25176815/32564126-20e1a93c-c4ab-11e7-9089-31f8868b9b89.png)

Course Index page with course cards

![Course Index page](https://user-images.githubusercontent.com/25176815/32564140-2c017b62-c4ab-11e7-8444-b2325c8cd0ec.png)

@cehwitham   - Please review!
 @Pro-Paul - Pls feel free to add any other points to new [ticket](https://github.com/NHSLeadership/moodle-theme_nightingale/issues/47) wrt course Cards that might have been missed out