### PR TITLE
[refs #00007] Moodle Dashboard 

### DIFF
--- a/style/main.scss
+++ b/style/main.scss
@@ -12,6 +12,7 @@
 @import "middleware/middleware.course-view";
 @import "middleware/middleware.login";
 @import "middleware/middleware.home";
+@import "middleware/middleware.dashboard";
 
 /*
  * Importing Moodle related SASS for v1

--- a/style/middleware/_middleware.dashboard.scss
+++ b/style/middleware/_middleware.dashboard.scss
@@ -1,0 +1,50 @@
+/* ==========================================================================
+   #DASHBOARD
+   ========================================================================== */
+
+.block-myoverview .content-centred {
+  max-width: 900px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.tab-content > .tab-pane {
+  display: none;
+}
+
+.tab-content > .active {
+  display: block;
+}
+
+.block-myoverview .tab-content .tab-pane .row.text-xs-center {
+  text-align: center;
+}
+
+.block-myoverview .tab-content .tab-pane .text-xs-center .btn-group a.btn.btn-default {
+  @extend .c-tabs__link;
+  display: table-cell;
+  width: 40%;
+}
+
+.block-myoverview .tab-content .tab-pane .text-xs-center .btn-group a.btn.btn-default.active {
+  @extend .is-current;
+}
+
+.block-myoverview .tab-content .tab-pane div#courses-view-in-progress div#pc-for-in-progress div.courses-view-course-item div.course-info-container {
+  @extend .list-group-item;
+}
+
+// Hiding duplicate "Customise this page" button
+section[data-region="blocks-column"] div.breadcrumb-button.nonavbar.pull-xs-right div.singlebutton button[type="submit"] {
+  display: none;
+}
+
+
+// Copying Moodle's placeholder image CSS as is (responsive)
+.block_myoverview .empty-placeholder-image-lg {
+  height: 125px;
+}
+
+.block_myoverview .empty-placeholder-image-sm {
+  height: 50px;
+}

--- a/style/middleware/_middleware.dashboard.scss
+++ b/style/middleware/_middleware.dashboard.scss
@@ -2,12 +2,6 @@
    #DASHBOARD
    ========================================================================== */
 
-.block-myoverview .content-centred {
-  max-width: 900px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
 .tab-content > .tab-pane {
   display: none;
 }

--- a/style/middleware/_middleware.generic.scss
+++ b/style/middleware/_middleware.generic.scss
@@ -102,7 +102,56 @@ img:not([alt]) {
   outline: none;
 }
 
-// Some margin space just before the footer, at the end of main content area
+// Some margin space just before the footer, at the end of main content areas
 .o-layout--wide {
   margin-bottom: $global-spacing-unit;
+}
+
+// Hiding User Avatar for v1; To be pursued in future versions
+img.userpicture {
+  display: none;
+}
+
+// Generic Moodle classes used everywhere to be defined as is
+.hidden {
+  display: none;
+}
+
+.hidden-sm-up {
+  display: none;
+}
+
+.hidden-md-up {
+  display: none;
+}
+
+.text-xs-center {
+  text-align: center;
+}
+
+.m-t-3 {
+  margin-top: $global-spacing-unit;
+}
+
+.m-y-1 {
+  margin-top: $global-spacing-unit-small;
+}
+
+.m-b-1 {
+  margin-bottom: $global-spacing-unit-small;
+}
+
+.btn-group {
+  display: inline-block;
+}
+
+.list-group-item {
+  position: relative;
+  display: block;
+  border: 1px solid color('nhs-grey-pale');
+  padding: 0.75rem 1.25rem;
+}
+
+li {
+  list-style: none;
 }

--- a/style/middleware/_middleware.home.scss
+++ b/style/middleware/_middleware.home.scss
@@ -18,11 +18,11 @@ aside.block_site_main_menu {
 }
 
 // Course Cards on Home & Course Index page
-div[id="frontpage-course-list"] div.courses.frontpage-course-list-all, div.course_category_tree div.courses.category-browse {
+div[id="frontpage-course-list"] div.courses.frontpage-course-list-all, div.course_category_tree div.courses.category-browse, div[id="frontpage-course-list"] div.courses.frontpage-course-list-enrolled {
   @extend .c-media;
 }
 
-div[id="frontpage-course-list"] div.courses.frontpage-course-list-all div.coursebox, div.course_category_tree div.courses.category-browse div.coursebox {
+div[id="frontpage-course-list"] div.courses.frontpage-course-list-all div.coursebox, div.course_category_tree div.courses.category-browse div.coursebox, div[id="frontpage-course-list"] div.courses.frontpage-course-list-enrolled div.coursebox {
   @extend .c-media__masthead;
   margin-bottom: $global-spacing-unit;
 }
@@ -35,12 +35,12 @@ div[id="frontpage-course-list"] div.coursebox div.content div.courseimage img, d
   @extend .c-media__media;
 }
 
-div[id="frontpage-course-list"] div.courses.frontpage-course-list-all div.coursebox div.info, div.course_category_tree div.courses.category-browse div.coursebox div.info {
+div[id="frontpage-course-list"] div.courses.frontpage-course-list-all div.coursebox div.info, div.course_category_tree div.courses.category-browse div.coursebox div.info, div[id="frontpage-course-list"] div.courses.frontpage-course-list-enrolled div.coursebox div.info {
   @extend .c-media__emblem;
 }
 
 // Changing font styling of Course title to be slightly smaller for Course cards than usual <h3> fonts
-div[id="frontpage-course-list"] div.courses.frontpage-course-list-all div.coursebox div.info h3, div.course_category_tree div.courses.category-browse div.coursebox div.info h3 {
+div[id="frontpage-course-list"] div.courses.frontpage-course-list-all div.coursebox div.info h3, div.course_category_tree div.courses.category-browse div.coursebox div.info h3, div[id="frontpage-course-list"] div.courses.frontpage-course-list-enrolled div.coursebox div.info h3 {
   @extend .c-media__emblem;
   line-height: 1.52;
   font-size: $global-font-size-h4;

--- a/templates/block_myoverview/progress-chart.mustache
+++ b/templates/block_myoverview/progress-chart.mustache
@@ -1,0 +1,39 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template block_myoverview/progress-chart
+
+    This template renders a doughnut chart to show course progress.
+
+    Example context (json):
+    {
+        "hasprogress": true,
+        "progress": "60"
+    }
+}}
+<div class="progress-chart-container m-b-1">
+    {{#hasprogress}}
+    <div class="progress-doughnut c-progress-wheel" data-percent={{progress}}>
+        <div class="progress-text {{#progress}}has-percent{{/progress}} c-progress-wheel__text">{{progress}}&#37;</div>
+    </div>
+    {{/hasprogress}}
+    {{^hasprogress}}
+    <div class="no-progress">
+        {{#pix}} i/course {{/pix}}
+    </div>
+    {{/hasprogress}}
+</div>


### PR DESCRIPTION
The Dashboard page bits done are

- 2 column layout
- Right-side blocks
- Styled "Timeline" & "Courses" tabs
- Added generic styling needed on Dashboard page borrowed from core Moodle styles as is
- Styled course cards in Dashboard area
- Progress wheel
- Fixed Home page > Enrolled Courses blocks as part of this ticket

Due to Moodle’s core template not having course background image for course cards in Dashboard area & having a progress wheel instead of a bar — have styled it accordingly without changing the layout for v1.0 atleast.

Will pursue any pending tasks for Dashboard with modified designs in [separate ticket (https://github.com/NHSLeadership/moodle-theme_nightingale/issues/49)

Dashboard on Moodle Local
![Dashboard](https://user-images.githubusercontent.com/25176815/32905068-dfa74b06-caf0-11e7-99af-9073f3c8bf73.png)

Dashboard > Timeline Tab > Sort by Courses
![Dashboard > Timeline > Sort by Courses](https://user-images.githubusercontent.com/25176815/32905089-ef7bd7cc-caf0-11e7-9df3-ad8b1269e442.png)

Dashboard > Courses Tab
![Dashboard > Courses Tab](https://user-images.githubusercontent.com/25176815/32905127-07976790-caf1-11e7-9809-b4fa677728a9.png)

@cehwitham - Please review!
@Pro-Paul - Pls feel free to add any other points to [new ticket](https://github.com/NHSLeadership/moodle-theme_nightingale/issues/49) as and when you can think of for Dashboard area 