### PR TITLE
[refs #00024] Header alignment and other related fixes…

### DIFF
--- a/style/middleware/_middleware.course-view.scss
+++ b/style/middleware/_middleware.course-view.scss
@@ -39,7 +39,7 @@ form.navbuttontext.prev input[type="submit"] {
   @extend .c-btn--primary;
   @extend .c-btn--natural;
   white-space: normal;
-
+  height: $global-spacing-unit-large; // To make it look same height as Next button as it can shrink at times based on activity name's length
 }
 
 form.navbuttontext.next {
@@ -73,4 +73,9 @@ form.navbuttontext.next input[type="submit"] {
   @extend .c-sprite;
   @extend .c-sprite--play;
   @extend .c-media__emblem;
+}
+
+// Feedback :: Rate the topic -> heading needs to stay standard black as opposed to blue
+form[id="feedback_complete_form"] div.feedback_itemlist h3.delta.text-center {
+  color: color('nhs-black') !important;
 }

--- a/style/middleware/_middleware.forums.scss
+++ b/style/middleware/_middleware.forums.scss
@@ -101,7 +101,7 @@ div.indent .forumpost .content .posting {
 
 .indent div.indent {
   border-left: 4px solid color('nhs-grey-pale');
-  padding-left: 11px;
+  padding-left: $global-spacing-unit-tiny + $global-border-mid;
 }
 
 .forumpost .options .commands {
@@ -218,6 +218,24 @@ form[id="mformforum"] .form-inline label.form-check.fitem {
 
 button[id="searchform_button"] {
   margin-top: $global-spacing-unit-tiny;
+}
+
+// Move & Pin Discussion
+div.movediscussionoption {
+  margin-top: $global-spacing-unit-small;
+}
+
+div.movediscussionoption input.btn.btn-secondary {
+  margin-top: $global-spacing-unit-tiny;
+}
+
+#page-mod-forum-discuss .discussioncontrols .discussioncontrol.pindiscussion {
+  margin-top: $global-spacing-unit-small;
+}
+
+// Subscription icon dots
+div.discussionsubscription i.icon.fa.fa-envelope-o.fa-fw {
+  margin-right: $global-spacing-unit-tiny / 2;
 }
 
 /**

--- a/style/middleware/_middleware.header.scss
+++ b/style/middleware/_middleware.header.scss
@@ -38,3 +38,12 @@ ul.c-nav-primary__sub-links li .courses.frontpage-course-list-all a {
   padding-right: 1ch;
   padding-left: 1ch;
 }
+
+/* Fixing Header alignments until permanent adjustments made into Nightingale */
+.c-nav-primary__link {
+  margin-top: $global-spacing-unit-small;
+}
+
+.c-page-header {
+  margin-bottom: $global-border-mid;
+}


### PR DESCRIPTION
Things fixed are

- Header menu items alignment 
- Margin space below header
![Header](https://user-images.githubusercontent.com/25176815/33128613-effd98f0-cf84-11e7-9225-70927ede1aa6.png)


- Add height to Prev button from Navbutton plugin

- Change “Rate topic” heading from blue to default nightingale heading styles
![Feedback heading](https://user-images.githubusercontent.com/25176815/33128580-c68ac646-cf84-11e7-93c9-7aef69ad195a.png)


- Space between Move/Pin bans on Forum page
![Space btwn btns](https://user-images.githubusercontent.com/25176815/33128527-979f5b30-cf84-11e7-9a10-a35c6afc19c2.png)


- New reply indentation
![Forum response indentation](https://user-images.githubusercontent.com/25176815/33127248-94eaeaee-cf7f-11e7-82a4-d23b5157c561.png)

@cehwitham - Pls review when you get a chance. Thanks!
