### PR TITLE
[refs #00055] Fixed Forum indentation for responses to parent post

### DIFF
--- a/style/middleware/_middleware.forums.scss
+++ b/style/middleware/_middleware.forums.scss
@@ -88,6 +88,8 @@
  */
 .indent {
   @extend .c-comments;
+  border-left: 4px solid color('nhs-grey-pale');
+  padding-left: $global-spacing-unit-tiny + $global-border-mid;
 }
 
 .forumpost .author {


### PR DESCRIPTION
Fixed Forum indentation for responses to parent post (a bug found by @Pro-Paul while walking through Moodle Staging site)

![Forum-indentation](https://user-images.githubusercontent.com/25176815/33314742-7e2a8c5a-d426-11e7-891f-45e86edf8cca.png)

