### PR TITLE
[refs #00036] Forum subscription links hidden for Students …

### DIFF
--- a/javascript/main.js
+++ b/javascript/main.js
@@ -10,6 +10,7 @@ M.theme_nhsla_nightingale.main.init = function(Y, is_student) {
         // Hiding forum Group Selector if logged in user is Student
         if(is_student == true) {
             $(".groupselector").hide();
+            $("div#region-main-settings-menu").hide();
         }
 
     // End of Moodle Modification


### PR DESCRIPTION
Hidden forum subscription links on Forum related pages if logged in user is a Student. This is done through same JS which is used to show "Contact" as the header menu item instead of "Site Admin".

![Forum-page-for-students](https://user-images.githubusercontent.com/25176815/33315881-dc67811c-d429-11e7-9dbd-cae07a808c92.png)
