### PR TITLE
[refs #00053] Video player issue

### DIFF
--- a/style/middleware/_middleware.course-view.scss
+++ b/style/middleware/_middleware.course-view.scss
@@ -63,17 +63,7 @@ form.navbuttontext.next input[type="submit"] {
   background: none;
 }
 
-// To give light overlay, although it wont work if we have a default poster image which overrides any background relay
-.mediaplugin.mediaplugin_videojs {
-  @extend .c-media__masthead;
-}
-
-// Play button
-.video-js .vjs-big-play-button {
-  @extend .c-sprite;
-  @extend .c-sprite--play;
-  @extend .c-media__emblem;
-}
+// @TO-DO: Get Nightingale styles in place for Video & Play button
 
 // Feedback :: Rate the topic -> heading needs to stay standard black as opposed to blue
 form[id="feedback_complete_form"] div.feedback_itemlist h3.delta.text-center {


### PR DESCRIPTION
Moodle's internal Video JS plugin has lots of layers of CSS which breaks at some point when we add our Nightingale despite of retaining existing classes thus breaking the controls of Pause/Rewind/Full screen after the video starts playing.

This is trickier and more time-consuming than anticipated and will require looking into in future versions. For now, have simply removed our styles to revert to default ones.

![Default Style](https://user-images.githubusercontent.com/25176815/33483321-2e884cb6-d695-11e7-88c2-40834b1b98fe.png)


@cehwitham - Pls review