### PR TITLE
[refs #00063] Fixed Cookie banner to show on all pages until dismissed

### DIFF
--- a/layout/columns2.php
+++ b/layout/columns2.php
@@ -37,9 +37,12 @@ $jsmodule = array(
   'fullpath' => new moodle_url('/theme/nightingale/javascript/main.js')
 );
 
+
 $PAGE->requires->js_init_call('M.theme_nightingale.main.init', $theme_nightingale_variables, false, $jsmodule);
 $PAGE->requires->jquery();
 $PAGE->requires->jquery_plugin('ui');
+// Calling nightingale's internal cookie.js file
+$PAGE->requires->js(new moodle_url('/theme/nightingale/node_modules/nightingale/js/cookies.js'));
 
 user_preference_allow_ajax_update('drawer-open-nav', PARAM_ALPHA);
 require_once($CFG->libdir . '/behat/lib.php');

--- a/layout/login.php
+++ b/layout/login.php
@@ -25,13 +25,8 @@ defined('MOODLE_INTERNAL') || die();
 $bodyattributes = $OUTPUT->body_attributes();
 $themesettings = theme_nightingale_get_html_for_settings($OUTPUT, $PAGE);
 
-// Call Theme Nightingale's cookie JS file
-$jsmodule = array(
-  'name' => 'theme_nightingale',
-  'fullpath' => new moodle_url('/theme/nightingale/node_modules/nightingale/js/cookies.js')
-);
-
-$PAGE->requires->js_init_call('M.theme_nightingale.cookies', null, false, $jsmodule);
+// Calling nightingale's internal cookie.js file
+$PAGE->requires->js(new moodle_url('/theme/nightingale/node_modules/nightingale/js/cookies.js'));
 
 $templatecontext = [
     'sitename' => format_string($SITE->shortname, true, ['context' => context_course::instance(SITEID), "escape" => false]),

--- a/lib.php
+++ b/lib.php
@@ -255,7 +255,7 @@ function theme_nightingale_get_cookieribbonhtml($cookieribbon) {
 
       case 'yes':
       default:
-        $cookieribbonhtml = '<div class="c-ribbon  u-margin-bottom" id="jsCookieRibbon">
+        $cookieribbonhtml = '<div class="c-ribbon" id="jsCookieRibbon">
 
                                 <div class="o-wrapper">
   

--- a/templates/header.mustache
+++ b/templates/header.mustache
@@ -17,6 +17,7 @@
 {{!
     Page header.
 }}
+{{{ cookieribbonhtml }}}
 {{{ ribbonhtml }}}
 {{{ partnershipinfo }}}
 <header role="banner" class="c-page-header" id="jsPageHeader">

--- a/templates/login.mustache
+++ b/templates/login.mustache
@@ -51,7 +51,7 @@
                 <div class="o-wrapper">
                     <div class="card-title">
                         {{#logosrc}}
-                            <h2><img src="{{logosrc}}" title="{{sitename}}" alt="{{sitename}}" width="204" height="62" class="c-page-header__logo" /></h2>
+                            <h2 class="u-margin-top"><img src="{{logosrc}}" title="{{sitename}}" alt="{{sitename}}" width="204" height="62" class="c-page-header__logo" /></h2>
                         {{/logosrc}}
                         {{^logosrc}}
                             <h2>{{sitename}}</h2>


### PR DESCRIPTION
Cookie banner is now made so that it shows on all pages until dismissed regardless of the nature of user signed in.

Cookie banner on Login page when not dismissed
<img width="1252" alt="Cookie banner on Login" src="https://user-images.githubusercontent.com/25176815/33725080-0d3800be-db69-11e7-9247-1e87c09db9f4.png">

Cookie banner on other pages when not dismissed
<img width="1267" alt="Cookie banner on Home page" src="https://user-images.githubusercontent.com/25176815/33725112-2020017c-db69-11e7-8d10-faaa3ef84cbc.png">

Once it's dismissed, the browser remembers the preferences and doesn't show the banner again on any page.

@cehwitham - Pls review when you get time! Thanks!