### PR TITLE
[refs #00013] Styled User Profile page and related pages

### DIFF
--- a/style/main.scss
+++ b/style/main.scss
@@ -13,6 +13,7 @@
 @import "middleware/middleware.login";
 @import "middleware/middleware.home";
 @import "middleware/middleware.dashboard";
+@import "middleware/middleware.user-profile";
 
 /*
  * Importing Moodle related SASS for v1

--- a/style/middleware/_middleware.generic.scss
+++ b/style/middleware/_middleware.generic.scss
@@ -33,6 +33,10 @@ textarea {
   @extend .c-btn--primary;
 }
 
+div.singlebutton {
+  margin-bottom: $global-spacing-unit-tiny;
+}
+
 // Certain submit, primary, secondary buttons need special tracking to have proper Nightingale classes
 input[type="submit"] {
   @extend .c-btn--submit;

--- a/style/middleware/_middleware.user-profile.scss
+++ b/style/middleware/_middleware.user-profile.scss
@@ -1,0 +1,103 @@
+/* ==========================================================================
+   #USER PROFILE
+   ========================================================================== */
+
+// User profile blocks
+div.userprofile div.profile_tree section.node_category {
+
+  border: 1px solid color('nhs-grey-pale');
+  margin-bottom: $global-spacing-unit-tiny;
+  padding: $global-spacing-unit-tiny;
+  border-radius: 0.25rem;
+
+}
+
+// Usage of dl, dt, dd
+dt {
+  @extend label;
+}
+
+// Forum Preferences :: Duplicate 'Forum Tracking' link
+fieldset[id="id_trackreadposts"] legend.ftoggler {
+  display: none;
+}
+
+// Change Password :: Heading
+fieldset[id="id_changepassword"] legend.ftoggler {
+  @extend h3;
+}
+
+// Message Preferences
+div.checkbox-container label {
+  display: inline-block;
+  margin-left: $global-spacing-unit-tiny;
+}
+
+span.loading-icon {
+  display: none;
+}
+
+div.preferences-page-container div.preferences-container table.preference-table {
+  @extend .c-table-data;
+}
+
+td.align-bottom {
+  vertical-align: bottom;
+}
+
+div.preferences-page-container div.preferences-container table.preference-table .span6.col-xs-6 {
+  float: left;
+  width: 50%;
+}
+
+div.disabled-message {
+  display: none;
+}
+
+
+// Notification Preferences :: Pretty much retaining Moodle style to get rid of the addtl text 'Requires configuration' in tbl header
+div.hover-tooltip-container {
+  position: relative;
+}
+
+div.hover-tooltip-container span.config-warning {
+  display: none;
+}
+
+div.hover-tooltip-container div.hover-tooltip {
+  opacity: 0;
+  visibility: hidden;
+  position: absolute;
+  left: 50%;
+  top: calc(-50% - 5px);
+  -webkit-transform: translate(-50%, -50%);
+  -moz-transform: translate(-50%, -50%);
+  -ms-transform: translate(-50%, -50%);
+  -o-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
+  background-color: #fff;
+  border: 1px solid rgba(0, 0, 0, .2);
+  border-radius: .3rem;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  padding: $global-spacing-unit-tiny;
+  white-space: nowrap;
+  -webkit-transition: opacity .15s, visibility .15s;
+  -o-transition: opacity .15s, visibility .15s;
+  transition: opacity .15s, visibility .15s;
+  z-index: 1000;
+}
+
+
+// Edit Profile
+div.collapsible-actions a.collapseexpand {
+  display: none;
+}
+
+fieldset.clearfix.collapsible legend.ftoggler {
+  display: none;
+}
+
+a.btn.btn-link.p-a-0 {
+  display: none; // Hiding help info icon buttons almost invisible in appearance, and not required in Nightingale version
+}


### PR DESCRIPTION
The layout of the page sits in core file `lib/myprofilelib.php` and attempts to customise it have not been successful due to the nature of file (lib files being non-modifiable in Moodle in most cases). 

So, have simply styled profile & related pages that shows up on clicking different links from within the Profile page with Nightingale CSS and by tweaking some Admin settings.

User Profile Page
![User-Profile-Page](https://user-images.githubusercontent.com/25176815/33894335-a0518542-df55-11e7-8c64-ee4957f6beb1.png)

Edit Profile
![Edit Profile](https://user-images.githubusercontent.com/25176815/33894350-aa342ae2-df55-11e7-8ef5-fe03b84df3d0.png)

Change Password
![Change Password](https://user-images.githubusercontent.com/25176815/33894378-bf9ed2ba-df55-11e7-94fc-5981b41e93a1.png)

Message Preferences
![Message Preferences](https://user-images.githubusercontent.com/25176815/33894451-f2c74dd4-df55-11e7-887b-0465bc44be3f.png)

Notification Preferences
![Notification Preferences](https://user-images.githubusercontent.com/25176815/33894481-02fa61b4-df56-11e7-83bf-72cb5991d326.png)

Complete Report
![Complete Report](https://user-images.githubusercontent.com/25176815/33894497-0d993348-df56-11e7-9d00-588fffc971b3.png)

Today's Logs
![screen shot 2017-12-12 at 16 05 23](https://user-images.githubusercontent.com/25176815/33894552-2e79f868-df56-11e7-9365-ab5f45ebb066.png)

@cehwitham - Please review as and when you can. Thanks!