### PR TITLE
Assignment Pages Styling

### DIFF
--- a/style/main.scss
+++ b/style/main.scss
@@ -14,6 +14,7 @@
 @import "middleware/middleware.home";
 @import "middleware/middleware.dashboard";
 @import "middleware/middleware.user-profile";
+@import "middleware/middleware.assignments";
 
 /*
  * Importing Moodle related SASS for v1

--- a/style/middleware/_middleware.assignments.scss
+++ b/style/middleware/_middleware.assignments.scss
@@ -1,0 +1,49 @@
+/* ==========================================================================
+   #ASSIGNMENT (turnitin) PAGES
+   ========================================================================== */
+
+div.listbar-container div.top.listbar div.dataTables_length label, div.dataTables_length label {
+  font-size: $global-font-size-h5;
+  font-weight: normal;
+}
+
+a[id="nonsubmitters_4"] {
+  font-size: $global-font-size-h5;
+}
+
+a.messages_inbox.cboxElement {
+  font-size: $global-font-size-h5;
+}
+
+div[id="refresh_4"], div[id="refreshing_4"] {
+  float: left;
+  font-size: $global-font-size-h5;
+  margin-left: $global-spacing-unit-large;
+  text-align: center;
+}
+
+span.loading-message {
+  font-size: $global-font-size-h5;
+  font-weight: normal;
+}
+
+td.rubric_qm.cell.c6.lastcol {
+  width: 16%;
+}
+
+.listbar label {
+  font-size: $global-font-size-h5;
+}
+
+.partDetails a.editable-click:before {
+    right: -$global-spacing-unit-tiny;
+}
+
+div.dataTables_filter label {
+  font-size: $global-font-size-h5;
+  font-weight: normal;
+}
+
+div.listbar-container div.top.listbar div[id="4_length"], div.members.members-instructors div.dataTables_length {
+  @extend .c-form-dropdown;
+}

--- a/style/middleware/_middleware.assignments.scss
+++ b/style/middleware/_middleware.assignments.scss
@@ -35,6 +35,10 @@ td.rubric_qm.cell.c6.lastcol {
   font-size: $global-font-size-h5;
 }
 
+div[id="cboxWrapper"], div[id="cboxLoadedContent"] {
+  height: round(10.16 * $global-spacing-unit-large) !important;
+}
+
 .partDetails a.editable-click:before {
     right: -$global-spacing-unit-tiny;
 }


### PR DESCRIPTION
Hi @cehwitham ,

Following Turnitin setup with Sandbox & live environments complete & documented, I have done few style changes to make assignment pages resemble a bit like Nightingale keeping turnitin's own styles intact too. Removed Navbuttons configuration as it's not required for Assignment pages.

Here is how the pages look now for most part:
![Turnitin-Submission-Tab](https://user-images.githubusercontent.com/25176815/36152224-2ed23f26-10c2-11e8-977b-35132f4806eb.png)

![Turnitin-Tutors-Tab](https://user-images.githubusercontent.com/25176815/36152349-ab841f58-10c2-11e8-928e-fb1b2a7f0bb3.png)

![Turnitin-Students-Tab](https://user-images.githubusercontent.com/25176815/36152290-6ca29b8e-10c2-11e8-9202-6545c67c7a91.png)

![Turnitin-User-Agreement-Modal-popup](https://user-images.githubusercontent.com/25176815/36152309-7d5075c8-10c2-11e8-8b14-49ac950f19cc.png)

Please review the PR as and when you get time. Thanks!