### PR TITLE
[refs #00074] Adjusted bullet list style to be none for footer only

### DIFF
--- a/style/middleware/_middleware.generic.scss
+++ b/style/middleware/_middleware.generic.scss
@@ -156,6 +156,6 @@ img.userpicture {
   padding: 0.75rem 1.25rem;
 }
 
-li {
+.c-page-footer__nav-item li {
   list-style: none;
 }


### PR DESCRIPTION
This is what bullet lists would look like everywhere except footer

<img width="1042" alt="screen shot 2018-06-19 at 17 53 50" src="https://user-images.githubusercontent.com/25176815/41612108-ca9291e2-73e9-11e8-834d-c9be53dd3f81.png">
