### PR TITLE
[refs #00082] Corrected mediaplugin CSS to fix WSIWYG n player alignment

### DIFF
--- a/style/middleware/_middleware.course-view.scss
+++ b/style/middleware/_middleware.course-view.scss
@@ -55,6 +55,7 @@ span.navbuttontext.prev-span {
 // Media Plugin
 div[id="video_player"] .mediaplugin.mediaplugin_videojs {
   width: 100%;
+  max-width: 100%;
 }
 
 // Video Plugin

--- a/style/middleware/_middleware.course-view.scss
+++ b/style/middleware/_middleware.course-view.scss
@@ -52,6 +52,11 @@ span.navbuttontext.prev-span {
   float: right;
 }
 
+// Media Plugin
+div[id="video_player"] .mediaplugin.mediaplugin_videojs {
+  width: 100%;
+}
+
 // Video Plugin
 .video-js {
   background: none;


### PR DESCRIPTION
This is how it looks when re-aligned

<img width="653" alt="screen shot 2018-06-27 at 17 23 58" src="https://user-images.githubusercontent.com/25176815/41986777-0321b394-7a2f-11e8-8e8d-4a82a6d2f2a6.png">

@cehwitham  - Pls review when you get time, thanks!